### PR TITLE
Create 15650.py

### DIFF
--- a/Coding_Test_Python/백준/15650.py
+++ b/Coding_Test_Python/백준/15650.py
@@ -1,0 +1,14 @@
+N, M = map(int, input().split())
+answer = []
+
+def backtrack(path, depth) :
+    if depth == M :
+        print(*path)
+        return
+    for i in range(path[-1] + 1, N+1) :
+        path.append(i)
+        backtrack(path, depth+1)
+        path.pop()
+
+for first_num in range(1, N+1) :
+    backtrack([first_num], 1)


### PR DESCRIPTION
## 📄 문제 정보

- **플랫폼**: 백준
- **문제 번호 / 이름**: 15650/N과 M (2)
- **링크**: https://www.acmicpc.net/problem/15650

---

## ❓ 문제 설명

> 자연수 N과 M이 주어졌을 때, 아래 조건을 만족하는 길이가 M인 수열을 모두 구하는 프로그램을 작성하시오.
1부터 N까지 자연수 중에서 중복 없이 M개를 고른 수열
고른 수열은 오름차순이어야 한다.

---

## ✏️ 문제 조건

- **입력**: 자연수 N과 M이 주어진다. (1 ≤ M ≤ N ≤ 8)
- **출력**: 조건을 만족하는 수열을 출력한다. 중복되는 수열을 여러 번 출력하면 안되며, 각 수열은 공백으로 구분해서 출력해야 한다.

수열은 사전 순으로 증가하는 순서로 출력해야 한다.
- **제약조건**:  (1 ≤ M ≤ N ≤ 8)
- 시간, 공간 제약 : 1초 512GB

---

## 💡 아이디어 / 접근

- 처음 떠올린 풀이 아이디어
    - Backtracking

---

## ✅ 내 풀이

### 🔹 풀이 설명

- N과 M 1과 동일, 단 for문으로 가능한 후보군을 탐색할 때, path[-1] + 1, N+1로 한정함
- 이렇게 하면 오류가 뜰 줄 알았음(path[-1]이 N인 경우). 근데 그냥 backtrack을 더이상 안 이어가는 거지 오류가 안 뜸(이 부분이 `pruning`이라고 할 수 있는 것 같음. DFS이지만, 가지치기를 한다는 것이 여기서 드러난다. 

### 🔹 코드

```python

N, M = map(int, input().split())
answer = []

def backtrack(path, depth) :
    if depth == M :
        print(*path)
        return
    for i in range(path[-1] + 1, N+1) :
        path.append(i)
        backtrack(path, depth+1)
        path.pop()

for first_num in range(1, N+1) :
    backtrack([first_num], 1)
```

### 🔹 시간 복잡도

- `O(N^M)`
