### PR TITLE
Create 15654.py N과 M(5)

### DIFF
--- a/Coding_Test_Python/백준/15654.py
+++ b/Coding_Test_Python/백준/15654.py
@@ -1,0 +1,23 @@
+N, M = map(int, input().split())
+
+numbers = list(map(int, input().split()))
+numbers.sort()
+
+def backtrack(path, depth) :
+    # 종료 조건
+    if depth == M :
+        print(*path)
+        return
+    
+    # 후보군 탐색
+    for next_idx in range(N) :
+        # 유효한 선택 인 겨우(중복이 불가능한 경우 제외)
+        if numbers[next_idx] not in path :
+            # 상태 변경
+            path.append(numbers[next_idx])
+            backtrack(path, depth + 1)
+            #상태 복원
+            path.pop()
+            
+for first_idx in range(N) :
+    backtrack([numbers[first_idx]], 1)


### PR DESCRIPTION
## 📄 문제 정보

- **플랫폼**: 백준
- **문제 번호 / 이름**:  15654/N과 M (5)
- **링크**: https://www.acmicpc.net/problem/15654

---

## ❓ 문제 설명

> N개의 자연수와 자연수 M이 주어졌을 때, 아래 조건을 만족하는 길이가 M인 수열을 모두 구하는 프로그램을 작성하시오. N개의 자연수는 모두 다른 수이다.

N개의 자연수 중에서 M개를 고른 수열

---

## ✏️ 문제 조건

- **입력**: 첫째 줄에 N과 M이 주어진다. (1 ≤ M ≤ N ≤ 8)
둘째 줄에 N개의 수가 주어진다. 입력으로 주어지는 수는 10,000보다 작거나 같은 자연수이다.
- **출력**:한 줄에 하나씩 문제의 조건을 만족하는 수열을 출력한다. 중복되는 수열을 여러 번 출력하면 안되며, 각 수열은 공백으로 구분해서 출력해야 한다.

수열은 사전 순으로 증가하는 순서로 출력해야 한다.
- **제약조건**: . (1 ≤ M ≤ N ≤ 8)

---

## 💡 아이디어 / 접근

- 처음 떠올린 풀이 아이디어
    - idx로 접근해도 될 것 같고 numbers[idx]로 접근 가능하다. 나는 그냥 numbers[idx]로 접근을 해서, 동일하게 진행했다. 문제 시작 전에 증가하는 순서로 출력해야 한다는 조건이 있기에 sort()을 한번 진행헀다.

---

## ✅ 내 풀이

### 🔹 풀이 설명

- Backtrack, 모든 경우 다 탐색하긴 해야하지만, 중간에 가지치기 할 수 있기 때문에

### 🔹 코드

```python
N, M = map(int, input().split())

numbers = list(map(int, input().split()))
numbers.sort()

def backtrack(path, depth) :
    # 종료 조건
    if depth == M :
        print(*path)
        return
    
    # 후보군 탐색
    for next_idx in range(N) :
        # 유효한 선택 인 겨우(중복이 불가능한 경우 제외)
        if numbers[next_idx] not in path :
            # 상태 변경
            path.append(numbers[next_idx])
            backtrack(path, depth + 1)
            #상태 복원
            path.pop()
            
for first_idx in range(N) :
    backtrack([numbers[first_idx]], 1)
```

### 🔹 시간 복잡도

- `O(N^M)`
