### PR TITLE
Create 15663.py N과 M 9

### DIFF
--- a/Coding_Test_Python/백준/15663.py
+++ b/Coding_Test_Python/백준/15663.py
@@ -1,0 +1,29 @@
+from collections import defaultdict
+
+N, M = map(int, input().split())
+
+numbers = list(map(int, input().split()))
+numbers.sort()
+numbers_dic = defaultdict(int)
+for num in numbers :
+    numbers_dic[num] += 1
+
+def backtrack(path, depth) :
+    # 종료 조건
+    if depth == M :
+        print(*path)
+        return
+    
+    # 후보군 탐색
+    for nxt_num, cnt in numbers_dic.items() :
+        if cnt > 0 :
+            numbers_dic[nxt_num] -= 1
+            path.append(nxt_num)
+            backtrack(path, depth + 1)
+            numbers_dic[nxt_num] += 1
+            path.pop()
+          
+for start_num in numbers_dic.keys() :
+    numbers_dic[start_num] -= 1
+    backtrack([start_num], 1)
+    numbers_dic[start_num] += 1


### PR DESCRIPTION
## 📄 문제 정보

- **플랫폼**: 백
- **문제 번호 / 이름**: 15663/N과 M (9)
- **링크**: https://www.acmicpc.net/problem/15663

---

## ❓ 문제 설명

> N개의 자연수와 자연수 M이 주어졌을 때, 아래 조건을 만족하는 길이가 M인 수열을 모두 구하는 프로그램을 작성하시오.

N개의 자연수 중에서 M개를 고른 수열

---

## ✏️ 문제 조건

- **입력**:첫째 줄에 N과 M이 주어진다. (1 ≤ M ≤ N ≤ 8)

둘째 줄에 N개의 수가 주어진다. 입력으로 주어지는 수는 10,000보다 작거나 같은 자연수이다.
- **출력**: 한 줄에 하나씩 문제의 조건을 만족하는 수열을 출력한다. 중복되는 수열을 여러 번 출력하면 안되며, 각 수열은 공백으로 구분해서 출력해야 한다.

수열은 사전 순으로 증가하는 순서로 출력해야 한다.
- **제약조건**: 시간 1초 , 메모리 512MB

---

## 💡 아이디어 / 접근

- 처음 떠올린 풀이 아이디어
    -처음에는 defaultdict로 비슷한 문제가 푼 적이 있지만, 그게 아닐 거라고 생각했다. 그래서, 전과 동일하게 가되, 가능한 answer를 string으로 변환해서 set으로 관리 한 후, 마지막에 출력하도록 하니, 순서가 너무 어긋나서, set으로 그냥 출력된 걸 기록하고, 그때그때 출력되었는지 확인하고 검사해서 출력하도록 바꿨는데, 이것도 시간 초과가 났다. 그래서 defaultdict으로 그냥 검사하고, 하는 거겠구나! 해서 바꿨다.


---

## ✅ 내 풀이

### 🔹 풀이 설명

-  default dict을 사용해서 key는 numbers 자체를 사용했고, value로는 몇번 나왔는지를 기록했다,
   - `.items`를 통해서 순회를 했고, cnt가 0인 경우에는 무시하고, 나머지 경우에 대해서 backtrack을 진행했다. 이경우, default dict인 numbers_dic에 대해서도 그리고 path에 대해서도 #상태 변경과 상태 복원을 진행해야 했기에 조금 복잡했다. 

### 🔹 코드

```python
from collections import defaultdict

N, M = map(int, input().split())

numbers = list(map(int, input().split()))
numbers.sort()
numbers_dic = defaultdict(int)
for num in numbers :
    numbers_dic[num] += 1

def backtrack(path, depth) :
    # 종료 조건
    if depth == M :
        print(*path)
        return
    
    # 후보군 탐색
    for nxt_num, cnt in numbers_dic.items() :
        if cnt > 0 :
            numbers_dic[nxt_num] -= 1
            path.append(nxt_num)
            backtrack(path, depth + 1)
            numbers_dic[nxt_num] += 1
            path.pop()
          
for start_num in numbers_dic.keys() :
    numbers_dic[start_num] -= 1
    backtrack([start_num], 1)
    numbers_dic[start_num] += 1

```