### PR TITLE
단축키 지정[1283]

### DIFF
--- a/Coding_Test_Python/백준/1283_.py
+++ b/Coding_Test_Python/백준/1283_.py
@@ -1,0 +1,30 @@
+N = int(input())
+set_of_words = set()
+dic ={}
+answer =''
+for _ in range(N) :
+    option = input()
+    print_with_brackets = ''
+    not_printed = True
+    for word in option.split() :
+        if not_printed and word[0].lower() not in set_of_words :
+            print_with_brackets += f'[{word[0]}]{word[1:]} '
+            not_printed = False
+            set_of_words.add(word[0].lower())
+        else :
+            print_with_brackets +=word + " "
+    if not_printed :
+        print_with_brackets = ''
+        for char in option :
+            if char == " " :
+                print_with_brackets += " "
+                continue
+            if not_printed and char.lower() not in set_of_words :
+                print_with_brackets += f'[{char}]'
+                not_printed = False
+                set_of_words.add(char.lower())
+            else :
+                print_with_brackets += char
+    dic[option] = print_with_brackets
+    answer += (print_with_brackets) + '\n'
+print(answer)


### PR DESCRIPTION
## 📄 문제 정보

- **플랫폼**: 백준
- **문제 번호 / 이름**: 1283/단축키 지
- **링크**: https://www.acmicpc.net/problem/1283

---

## ❓ 문제 설명

> 한글 프로그램의 메뉴에는 총 N개의 옵션이 있다. 각 옵션들은 한 개 또는 여러 개의 단어로 옵션의 기능을 설명하여 놓았다. 그리고 우리는 위에서부터 차례대로 각 옵션에 단축키를 의미하는 대표 알파벳을 지정하기로 하였다. 단축키를 지정하는 법은 아래의 순서를 따른다.

먼저 하나의 옵션에 대해 왼쪽에서부터 오른쪽 순서로 단어의 첫 글자가 이미 단축키로 지정되었는지 살펴본다. 만약 단축키로 아직 지정이 안 되어있다면 그 알파벳을 단축키로 지정한다.
만약 모든 단어의 첫 글자가 이미 지정이 되어있다면 왼쪽에서부터 차례대로 알파벳을 보면서 단축키로 지정 안 된 것이 있다면 단축키로 지정한다.
어떠한 것도 단축키로 지정할 수 없다면 그냥 놔두며 대소문자를 구분치 않는다.
위의 규칙을 첫 번째 옵션부터 N번째 옵션까지 차례대로 적용한다.
---

## ✏️ 문제 조건

- **입력**: 첫째 줄에 옵션의 개수 N(1 ≤ N ≤ 30)이 주어진다. 둘째 줄부터 N+1번째 줄까지 각 줄에 옵션을 나타내는 문자열이 입력되는데 하나의 옵션은 5개 이하의 단어로 표현되며, 각 단어 역시 10개 이하의 알파벳으로 표현된다. 단어는 공백 한 칸으로 구분되어져 있다.
- **출력**:N개의 줄에 각 옵션을 출력하는데 단축키로 지정된 알파벳은 좌우에 [] 괄호를 씌워서 표현한다.
- **제약조건**: 2초 128MB

---

## 💡 아이디어 / 접근

- 처음 떠올린 풀이 아이디어
    -  구현 문제이다. 그냥 모든 조건을 분개해서 생각하면 되는 쉬운 문제였지만, 오류가 뜨는게 많았다. 그리고 문제가 적합하지 않은게, 똑같은 입력이 들어가면 이미 저장되어있는 단축키에 뜨는게 적절한 것 같은데, 이걸 고려하지 않기에 문제가 적절하지 않았던 것 같다.
      - 처음 오류는 검사용 set랑 boolean 함수는 다 만들어놓고, 이를 사요하지를 않았다. 조건 분개시, 꼭 `#상태 반영` 이라는 주석을 다는 연습을 해야겠다. 
      - 두번째 오류는 dic을 쓰긴 했지만, 여기서 dic은 해당 key에 대한 value가 있ㅇ으면 갈아끼우는 것도 아니고, 그냥 무시한다. 즉 비어있는, 아직 key가 없는 것에 대해서 추가만 가능하다. 


---

## ✅ 내 풀이

### 🔹 풀이 설명

- 생략,

### 🔹 코드

```python
N = int(input())
set_of_words = set()
dic ={}
answer =''
for _ in range(N) :
    option = input()
    print_with_brackets = ''
    not_printed = True
    for word in option.split() :
        if not_printed and word[0].lower() not in set_of_words :
            print_with_brackets += f'[{word[0]}]{word[1:]} '
            not_printed = False
            set_of_words.add(word[0].lower())
        else :
            print_with_brackets +=word + " "
    if not_printed :
        print_with_brackets = ''
        for char in option :
            if char == " " :
                print_with_brackets += " "
                continue
            if not_printed and char.lower() not in set_of_words :
                print_with_brackets += f'[{char}]'
                not_printed = False
                set_of_words.add(char.lower())
            else :
                print_with_brackets += char
    dic[option] = print_with_brackets
    answer += (print_with_brackets) + '\n'
print(answer)
```
<details>
<summary>클린 코드 변경</summary>

```python
N = int(input())
used_shortcuts = set()  # 사용했던 이력 관리하기 위한 set은 used_[], 여기서는 used shortcut
result = []

def is_available(char):  # 이건 굳이, 근데 if not in .. 이걸 그냥 따로 뺐음. 
    return char.lower() not in used_shortcuts and char != ' '

def apply_bracket(line):  # 깔끔한 함수명 (apply_ []) 
    words = line.split()
    for i, word in enumerate(words):  # enumerate 사용
        if is_available(word[0]):
            used_shortcuts.add(word[0].lower())
            words[i] = f'[{word[0]}]{word[1:]}'
            return ' '.join(words)
    
    # 문장 단위에서도 사용하지 못했다면 문자 단위 시도
    bracketed = ''
    for char in line:
        if is_available(char):
            used_shortcuts.add(char.lower())
            bracketed += f'[{char}]'
            line = line[len(bracketed)-2:]  # 괄호로 인해 길이 조정
            break
        else:
            bracketed += char
    return bracketed + line[len(bracketed):]

# 함수를 만들고, 따로 input을 처리.
# 무조건 input을 빼는게 더 깔끔해 보임. 
for _ in range(N):
    line = input()
    result.append(apply_bracket(line))

print('\n'.join(result))
```

##### 요약 정리
- is_avaliable 사용
- apply_ [], used_ [] 변수명 사용
- string을 통째로 관리하는 것이 아닌, 배열로 관리한 다음에 마지막에 한 줄씩 pring 하거나 join 함수 사용
- 
</summary>

### 🔹 시간 복잡도

- `O(N*최대 문자열 길이)
---

## 🔍 다른 풀이 / 참고 풀이

 - 모두 동일 
