### PR TITLE
NM과 K (1) [백준 18290]

### DIFF
--- a/Coding_Test_Python/백준/18290.py
+++ b/Coding_Test_Python/백준/18290.py
@@ -1,0 +1,52 @@
+import sys
+
+input = sys.stdin.readline
+answer = -(float('inf'))
+
+N, M, K = map(int, input().split())
+board = []
+for _ in range(N) :
+    board.append(list(map(int, input().split())))
+
+def add_visit(y, x, visited) :
+    new_visited = [row[:] for row in visited]
+    d = [[0,1],[0,-1],[1,0],[-1,0]]
+    new_visited[y][x] = True
+    for dir in range(4) :
+        ty, tx = y + d[dir][0], x + d[dir][1]
+        if ty >=0 and ty < N and tx >= 0 and tx < M :
+            new_visited[ty][tx] = True
+    return new_visited
+
+
+max_value = max(map(max, board))
+
+def dfs(y, x, depth, total, visited ) :
+    global answer
+    if depth == K :
+        answer = max(answer, total)
+        return
+    if total + (K - depth) * max_value < answer:
+        return
+    for i in range(N) :
+        for j in range(M) :        
+            #가능한 후보군
+            if visited[i][j] is False:
+                dfs(i, j, depth+1, total + board[i][j], add_visit(i, j, visited))
+visited = [[False]*M for _ in range(N)]
+
+
+
+
+for idx in range(N) :
+    for jdx in range(M) :
+        dfs(idx, jdx, 1, board[idx][jdx], add_visit(idx, jdx, visited))
+print(answer)
+
+
+
+'''가지치기가 제일 중ㅇ요했음!!! '''
+
+
+
+


### PR DESCRIPTION
## 📄 문제 정보

- **플랫폼**: 백준
- **문제 번호 / 이름**: NM과 K (1)/18290
- **링크**: https://www.acmicpc.net/problem/18290

---

## ❓ 문제 설명

> 크기가 N×M인 격자판의 각 칸에 정수가 하나씩 들어있다. 이 격자판에서 칸 K개를 선택할 것이고, 선택한 칸에 들어있는 수를 모두 더한 값의 최댓값을 구하려고 한다. 단, 선택한 두 칸이 인접하면 안된다. r행 c열에 있는 칸을 (r, c)라고 했을 때, (r-1, c), (r+1, c), (r, c-1), (r, c+1)에 있는 칸이 인접한 칸이다.

---

## ✏️ 문제 조건

- **입력**: 선택한 칸에 들어있는 수를 모두 더한 값의 최댓값을 출력한다.
- **출력**: 1 ≤ N, M ≤ 10, 1 ≤ K ≤ min(4, N×M), 격자판에 들어있는 수는 -10,000보다 크거나 같고, 10,000보다 작거나 같은 정수이다. 항상 K개의 칸을 선택할 수 있는 경우만 입력으로 주어진다.
- **제약조건**: 2초 512MB

---

## 💡 아이디어 / 접근

- 처음 떠올린 풀이 아이디어
    - dfs여야 할 것 같았는데, `Backtracking`이었다. 가지치기를 미리미리 해야 했던 것. dfs 통해서 지금까지 탐색한 게 목표한 K와 동일하면 answer를 큰 값으로 갱신하도록 했고, 그 다음에는 모든 가능한 후보 군을 이중 반복문을 통해서 구하도록 했습니다. visited 을 관리하면서 실제로 격자판을 선택한 경우와 , 선택한 격자판 주위를 다 visited=True로 처리하여, 다시 방문하지 않도록 했습니다. add_visit을 통해서 해당 작업을 수행했고, 처음에 visit을 입력 받은 것을 조작하다 보니까,  변화가 계속 누적되는 당연한 결과가 나왔습니다. 이는 [row[:] for row in visited]를 통해 얕은 복사를 하여 해결했습니다. 입력받은 좌표와, 좌표 주변 좌표들도 함께 visit 처리를 하고, 새로운 visit 이차 배열을 반환하도록 햇습니다. 그리고 모든 점에서 dfs를 시작하여, 가능한 모든 조합을 탐색하도록 했습니다. 처음에는 우하향, 으로 가도록 탐색하고자 했으나, 그러면 조건이 더 복잡해지기 때문에, N이 최댓값도 낮기에 완전 탐색을 사용했습니다. 
    - 하지만 이렇게 하면, 시간 초과가 났는데요, 불필요한 경우에도 계속 dfs로 탐색을 하기 때문이었습니다. 그래서 DFS에서 Backtracking으로 변경하기 위해서 , MAX 값 x (K - depth) 을 통해서, 애초에 희망이 없는 경우는 탐색을 더이상 이어가지 않도록 했습니다
---

## ✅ 내 풀이

### 🔹 풀이 설명

- 해당 문제는 가지치기 + DFS 구조인 backtracking으로 해결했습니다. 모든 점에 대해서 dfs를 시작했습니다. dfs 에 대해서는 만약 지금까지 탐색을 하여, K개를 탐색했다면, answer을 갱신하도록 했고, 가지치기를 위해서 (K-depth)을 사용하여, 입력받은 값중 가장 큰 값을 곱해서 total과 더했을 때, 현재까지 나왔던 answer보다 작으면 탐색을 더이상 이어가지 않도록 했습니다. 그리고 visited을 사용해서, 방문하면 안되는 선택된 좌표와, 선택된 좌표들의 주변 좌표들을 관리해서 조건을 만족시켰습니다. 

##### 보완된 답변
- 해당 문제는 `DFS 기반의 백트래킹`으로 선택한 칸과 그 4방향 인접 칸을 모두 `visited`처리했습니다. DFS는 모든 보드의 모든 칸에서 시작하며, depth==k일 때 합을 갱신합니다. `탐색 도중 가지치기 조건`으로 total + (K-depth) * max_Value < answer 을 사용해서, 최댓값만 고른다 해도 기존보다 작으면 탐색을 중단하도록 했습니다.
- 방문 관리는 add_visit()이라는 함수로 `깊은 복사`를 통해 처리되며, 백트래킹 구조를 유지하면서도 조건을 정확히 반영합니다. 
- 이때 2차원 리스트 대신, `Bit Masking`으로 압축하면 성능과 메모리를 더욱 최적화 할 수 있습니다.

### 🔹 코드

```import sys

input = sys.stdin.readline
answer = -(float('inf'))

N, M, K = map(int, input().split())
board = []
for _ in range(N) :
    board.append(list(map(int, input().split())))

def add_visit(y, x, visited) :
    new_visited = [row[:] for row in visited]
    d = [[0,1],[0,-1],[1,0],[-1,0]]
    new_visited[y][x] = True
    for dir in range(4) :
        ty, tx = y + d[dir][0], x + d[dir][1]
        if ty >=0 and ty < N and tx >= 0 and tx < M :
            new_visited[ty][tx] = True
    return new_visited


max_value = max(map(max, board))

def dfs(y, x, depth, total, visited ) :
    global answer
    if depth == K :
        answer = max(answer, total)
        return
    if total + (K - depth) * max_value < answer:
        return
    for i in range(N) :
        for j in range(M) :        
            #가능한 후보군
            if visited[i][j] is False:
                dfs(i, j, depth+1, total + board[i][j], add_visit(i, j, visited))
visited = [[False]*M for _ in range(N)]

for idx in range(N) :
    for jdx in range(M) :
        dfs(idx, jdx, 1, board[idx][jdx], add_visit(idx, jdx, visited))
print(answer)
```

## 📝 배운 점 / 정리

-  최댓값, 그리고 최솟값을 구할 때, 0으로 초기화를 하면 해당 문제처럼 음수가 포함되어 있는 경우 문제가 생긴다. 초기화는 항상 float('inf') 또는 sys.maxsize로 하도록.
- dfs에서 vistied관리하면, 그때 입력받은 배열을 그대로 조작하면, 그냥 누적되는 거임. deepcopy를 하거나 new_arr = [row[:] for row in arr] 이런 식으로 하기를.
- DFS를 할 때 시간초과가 나고 로직에 이상이 없으면 가지치기!!!!! 

