### PR TITLE
연결요소의 개수

### DIFF
--- a/py/11724.py
+++ b/py/11724.py
@@ -1,0 +1,39 @@
+import sys
+from collections import defaultdict, deque
+
+input = sys.stdin.readline
+sys.setrecursionlimit(2000)
+
+N, M = map(int, input().split())
+
+dic = defaultdict(list)
+
+for _ in range(M) :
+    a, b = map(int, input().split())
+    dic[a].append(b)
+    dic[b].append(a)
+    
+
+
+visited = [False] * (N + 1)
+
+
+def bfs( node) :
+    q = deque()
+    q.append(node)
+    while q :
+        node = q.popleft()
+        visited[node] = True
+        for neighbor in dic[node] :
+            if visited[neighbor] == False :
+                visited[neighbor] = True
+                q.append(neighbor)
+            
+            
+answer = 0       
+for i in range(1, N+1) :
+    if visited[i] == False :
+        bfs(i)
+        answer += 1
+
+print(answer)


### PR DESCRIPTION
## 📄 문제 정보

- **플랫폼**: 백준
- **문제 번호 / 이름**: 연결요소의 개수/11724
- **링크**: https://www.acmicpc.net/problem/11724

---

## ❓ 문제 설명

> 방향 없는 그래프가 주어졌을 때, 연결 요소 (Connected Component)의 개수를 구하는 프로그램을 작성하시오.

---

## ✏️ 문제 조건

- **입력**: 첫째 줄에 정점의 개수 N과 간선의 개수 M이 주어진다. (1 ≤ N ≤ 1,000, 0 ≤ M ≤ N×(N-1)/2) 둘째 줄부터 M개의 줄에 간선의 양 끝점 u와 v가 주어진다. (1 ≤ u, v ≤ N, u ≠ v) 같은 간선은 한 번만 주어진다.
- **출력**: 첫째 줄에 연결 요소의 개수를 출력한다.
- **제약조건**: N <= 1000
- **시간/공간 제한** : 3초, 512MB

---

## 💡 아이디어 / 접근
자유롭게 적기. 정말 생각 그대로.

- 처음 떠올린 풀이 아이디어
    - 연결 요소 : 연결 집합의 개수
    - 처음에는 DFS로 접근을 했습니다. 모든 노드를 다 탐색해야 한다고 생각을 해서 재귀 함수로 node와 visited을 인자로 주고 받으며 모든 가능한 조합을 탐색하도록 했으나, 이는 시간 초과가 났습니다. 

- 고려했던 다른 접근
    - 그러면 BFS로 접근을 해야겠다고 생각했고, 처음에도 visited을 인자로 주고 받으며 visited을 따로따로 접근했습니다. 이때까지 연결 요소라는 개념을 잘 몰랐기 때문에 잘못 접근을 했습니다. 연결 요소란 하나의 집합에 있는 노드의 개수라고 생각했지 집합 자체라고 생각을 하지 못해서 정말 많이 돌아갔습니다. 

- 선택한 접근 이유
    - 문제를 완전히 이해? 한 후에는 연결 요소라는 것이 집합을 의미하는 것이라는 안 후에는 visited을 인자로 받는 것이 아닌 globally 관리해야겠다는 생각이 들었습니다. 모든 가능한 node에 대해서는 bfs로 넓게 훑은 후에, 방문하게 되면 visited에 True 표시를 하고, 이를 bfs를 돈 횟수를 answer에 반영하도록 했습니다. 즉 연결 요소의 개수 == bfs를 시작한 횟수. 

---

## ✅ 내 풀이

### 🔹 풀이 설명

##### 알고리즘 인터뷰 답변
visited이라는 하나의 배열을 관리하여, 하나의 연결 요소에 포함되면 True에 표시하도록 했습니다. 하나의 노드에서 시작하여, 노드에 연결된 다른 노드들은 해시맵의 list로 관리하도록 했고, 이를 BFS를 통해서 하나의 노드에서 시작해서 인접한 노드들은 visited 처리를 함과 동시에 deque에 붙여서, 모든 노드와 인접한 노드와 인접한 노드를 모두 탐색하도록 했습니다. 그리고, 모든 노드에서부터 만약 아직 방문되지 않은 노드에 한해서 BFS를 돌도록 하였고, 이를 통해서 BFS를 시작한 횟수가 연결 요소의 개수로, 이를 반환하도록 했습니다. 

##### 알고리즘 인터뷰 답변 보완
각 노드의 인접한 노드들을 파이썬의 해시맵 형태인 defaultdict에 list 형태로 저장했습니다. 그리고 visited 배열을 사용해서 <mark>각 노드의 방문 여부를 기록</mark>했습니다. <mark>아직 방문되지 않은 노드를 시작점으로 하여서 BFS를 수행했고</mark>, BFS 과정에서<mark> 현재 노드를 deque에 넣었고, 인접 노드를 확인하며 방문 처리와 함께 노드를 q안에 추가했습니다.</mark> 연결된 노드를 탐색해서 하나의 연결 요소로 처리하도록 했습니다. 전체 노드를 순회하면서 방문하지 않은 노드에 대해서 BFS를 수행ㅎ했고, 그 횟수를 연결 요소의 개수로 간주해서 반환했습니다. 

### 🔹 코드

```python
import sys
from collections import defaultdict, deque

input = sys.stdin.readline
sys.setrecursionlimit(2000)

N, M = map(int, input().split())

dic = defaultdict(list)

for _ in range(M) :
    a, b = map(int, input().split())
    dic[a].append(b)
    dic[b].append(a)
    


visited = [False] * (N + 1)


def bfs( node) :
    q = deque()
    q.append(node)
    while q :
        node = q.popleft()
        visited[node] = True
        for neighbor in dic[node] :
            if visited[neighbor] == False :
                visited[neighbor] = True
                q.append(neighbor)
            
            
answer = 0       
for i in range(1, N+1) :
    if visited[i] == False :
        bfs(i)
        answer += 1

print(answer)
```

### 🔹 시간 복잡도

- `O(N+M)`
- 분석/이유 :<mark>각 간선은 양쪽 노드에서 한 번씩 순회됨 </mark>

---

## 🔍 다른 풀이 / 참고 풀이

> 다른 사람의 풀이 아이디어나 블로그, 해설 등에서 참고한 풀이
> 나와의 차이점, 배울 점, 내 풀이가 더 좋은 점 등.

---

### 풀이 #1

- 설명: DFS로도 가능
    - DFS로도 순회 가능함. 대신 가지치기 처럼 더이상 돌지 않을 조건에 대해서 명시하면 됐음.
    - 즉, 이 문제는 BFS, DFS 둘다 가능했음. 

- 코드:

```python
import sys

sys.setrecursionlimit(5000)
input = sys.stdin.readline


# dfs로 그래프를 탐색한다.
def dfs(start, depth):

    #해당 노드 방문체크 한다.
    visited[start] = True

    # 해당 시작점을 기준으로 계속해서 dfs로 그래프를탐색한다.
    for i in graph[start]:
        if not visited[i]:
            dfs(i, depth + 1)


N, M = map(int, input().split())
graph = [[] for _ in range(N + 1)]

for _ in range(M):
    a, b = map(int, input().split())
    graph[a].append(b)
    graph[b].append(a)

# 방문처리
visited = [False] * (1 + N)
count = 0  # 컴포넌트 그래프 개수 저장

# 1~N번 노드를 각각돌면서
for i in range(1, N + 1):
    if not visited[i]:  # 만약 i번째 노드를 방문하지 않았다면
        if not graph[i]:  # 만약 해당 정점이 연결된 그래프가 없다면
            count += 1  # 개수를 + 1
            visited[i] = True  # 방문 처리
        else:  # 연결된 그래프가 있다면
            dfs(i, 0)  # dfs탐색을 돈다.
            count += 1  # 개수를 +1

print(count)
```
---

### 풀이 #2

- 설명: 이중 리스트
    - 리스트 l에 idx로 a, b을 더하고, 만약 현존하는 l에 들어오는 a,b가 없으면 새로운 idx로 리스트에 추가하도록. 이건 DFS도 아니고 BFS도 아니지만 알고리즘적인 것이 아니라 직관적이어서 또 괜춘.
    

- 코드:

```python
def sum(i):
    for j in range(len(l)):
        if i!=j:
            if a in l[j] or b in l[j]:
                l[i]=l[i] | l[j]
                l.pop(j)
                return sum(i)

import sys
N,M=map(int,sys.stdin.readline().split())
l=[]
n=list(range(1,N+1))
for _ in range(M):
    a,b=map(int,sys.stdin.readline().split())
    if a in n:
        n.remove(a)
    if b in n:
        n.remove(b)
    if l:
        for i in range(len(l)):
            if a in l[i] or b in l[i]:
                if a in l[i]:
                    l[i].add(b)
                elif b in l[i]:
                    l[i].add(a)
                sum(i)
                break
            if i==len(l)-1:
                l.append(set([a,b]))
    else:
        l.append(set([a,b]))
print(len(l)+len(n))
```
---


## 📝 배운 점 / 정리

- dfs, bfs 문제 풀 때는 `import sys` , `sys.setrecursionlimit(2000)` 설정하고 문제를 풀어야 함. 
- BFS는 방문 처리를 한 후에 QUEUE에 넣어야 함. DFS도 재귀 호출하기 전에 넣어야 함. <mark> 노드를 큐나 재귀 호출에 넣기 전에 방문처리를 해야함</mark>
- dic → `graph`, node → `start_node` 같은 이름이 더 명확함

---

## 💥 실패했던 시도 기록

<details>
<summary>1차 풀이 (DFS, visited[node] 누락)</summary>

<pre><code>
from collections import defaultdict

N, M = map(int, input().split())

dic = defaultdict(list)

for _ in range(M):
    a, b = map(int, input().split())
    dic[a].append(b)
    dic[b].append(a)

visited = [False] * (N + 1)

def dfs(node):
    global answer
    for neighbor in dic[node]:
        if not visited[neighbor]:
            visited[neighbor] = True
            dfs(neighbor)

answer = 0
for i in range(1, N + 1):
    if not visited[i]:
        dfs(i)
        answer += 1

print(answer)
</code></pre>

</details>

<details>
<summary>2차 풀이 (DFS, sys.setrecursionlimit 추가)</summary>

<pre><code>
from collections import defaultdict
import sys
sys.setrecursionlimit(2000)

N, M = map(int, input().split())

dic = defaultdict(list)

for _ in range(M):
    a, b = map(int, input().split())
    dic[a].append(b)
    dic[b].append(a)

visited = [False] * (N + 1)

def dfs(node):
    global answer
    for neighbor in dic[node]:
        if not visited[neighbor]:
            visited[neighbor] = True
            dfs(neighbor)

answer = 0
for i in range(1, N + 1):
    if not visited[i]:
        dfs(i)
        answer += 1

print(answer)
</code></pre>

</details>

<details>
<summary>3차 풀이 (BFS로 전환, visited 누락)</summary>

<pre><code>
import sys
from collections import defaultdict, deque

sys.setrecursionlimit(2000)

N, M = map(int, input().split())

dic = defaultdict(list)

for _ in range(M):
    a, b = map(int, input().split())
    dic[a].append(b)
    dic[b].append(a)

visited = [False] * (N + 1)

def bfs(node):
    q = deque()
    q.append(node)
    while q:
        node = q.popleft()
        for neighbor in dic[node]:
            if not visited[neighbor]:
                visited[neighbor] = True
                bfs(neighbor)

answer = 0
for i in range(1, N + 1):
    if not visited[i]:
        bfs(i)
        answer += 1

print(answer)
</code></pre>

</details>

<details>
<summary>4차 풀이 (BFS 정상 작동)</summary>

<pre><code>
import sys
from collections import defaultdict, deque

sys.setrecursionlimit(2000)

N, M = map(int, input().split())

dic = defaultdict(list)

for _ in range(M):
    a, b = map(int, input().split())
    dic[a].append(b)
    dic[b].append(a)

visited = [False] * (N + 1)

def bfs(node):
    q = deque()
    q.append(node)
    while q:
        node = q.popleft()
        for neighbor in dic[node]:
            if not visited[neighbor]:
                visited[neighbor] = True
                q.append(neighbor)

answer = 0
for i in range(1, N + 1):
    if not visited[i]:
        bfs(i)
        answer += 1

print(answer)
</code></pre>

</details>
