### PR TITLE
Create 1092.py

### DIFF
--- a/py/1092.py
+++ b/py/1092.py
@@ -1,0 +1,35 @@
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+N = int(input())
+restrictions = list(map(int, input().split()))
+M = int(input())
+boxes = list(map(int, input().split()))
+if max(restrictions) < max(boxes) :
+    print(-1)
+    exit()
+restrictions.sort(reverse=True)
+boxes.sort(reverse=True)
+count = 0
+
+
+positions = [0]*N  # 각 크레인이 boxes 어디까지 옮겼는지 인덱스
+moved = [False]*M  # 옮겼는지 여부
+count = 0
+moved_count = 0
+
+while moved_count < M:
+    for i in range(N):  # 각 크레인 순서대로
+        while positions[i] < M:
+            # 아직 안 옮겼고, 크레인이 들 수 있으면
+            if not moved[positions[i]] and boxes[positions[i]] <= restrictions[i]:
+                moved[positions[i]] = True
+                moved_count += 1
+                positions[i] += 1
+                break
+            positions[i] += 1
+    count += 1
+
+print(count)


### PR DESCRIPTION
## 📄 문제 정보

- **플랫폼**: 백준
- **문제 번호 / 이름**: 1092/배
- **링크**: https://www.acmicpc.net/problem/1092

---

## ❓ 문제 설명

> 지민이는 항구에서 일한다. 그리고 화물을 배에 실어야 한다. 모든 화물은 박스에 안에 넣어져 있다. 항구에는 크레인이 N대 있고, 1분에 박스를 하나씩 배에 실을 수 있다. 모든 크레인은 동시에 움직인다.
각 크레인은 무게 제한이 있다. 이 무게 제한보다 무거운 박스는 크레인으로 움직일 수 없다. 모든 박스를 배로 옮기는데 드는 시간의 최솟값을 구하는 프로그램을 작성하시오.

---

## ✏️ 문제 조건

- **입력**: 첫째 줄에 N이 주어진다. N은 50보다 작거나 같은 자연수이다. 둘째 줄에는 각 크레인의 무게 제한이 주어진다. 이 값은 1,000,000보다 작거나 같다. 셋째 줄에는 박스의 수 M이 주어진다. M은 10,000보다 작거나 같은 자연수이다. 넷째 줄에는 각 박스의 무게가 주어진다. 이 값도 1,000,000보다 작거나 같은 자연수이다.
- **출력**: 첫째 줄에 모든 박스를 배로 옮기는데 드는 시간의 최솟값을 출력한다. 만약 모든 박스를 배로 옮길 수 없으면 -1을 출력한다.
- **제약조건**:
- **시간/공간 제한** : 2초, 128MB

---

## 💡 아이디어 / 접근
자유롭게 적기. 정말 생각 그대로.

- 처음 떠올린 풀이 아이디어
    - 비슷한 문제를 예전에 풀이했을 때, greedy로 접근했던 것이 기억나서 정렬을 한 후, 앞에서부터 하나씩 삭제해 가는 방식으로 햇으나, 그러면 666222 일 때 crane이 6 3 이면, 앞에서부터만 고려하기 때문에 4번으로 나오는 오류가 발생했음. 

- 고려했던 다른 접근
    - 그래서 deque로 접근해서, 맨앞과 맨뒤를 pop했지만, 이도 오류가 발생했었음. 

- 선택한 접근 이유
    - 이 방법은 제일 무거운 것부터 고려하되, 가능한 crane 무게도 가장 무거운 것으로 골라야 함. 그리고 이를 queue로 pop을 하면서 관리하면 시간 초과가 나기 때문에, 크레인이 어디까지 옮겼는지를 관리하는 배열과, 옮겼는지의 여부를 관리하는 배열 두개를 추가해야 했다. 그 후로 전체가 다 옮겨지기를 while문으로 관리하고, 그 다음에는 crane 순서대로(큰 것 부터) 모든 아직 안 옮긴, 큰 것 중에서 크레인이 들 수 있는 것에 대해서 이동시키면서 배열 조작, 을 하도록 했습니다. 

---

## ✅ 내 풀이

### 🔹 풀이 설명

##### 알고리즘 인터뷰 답변
crane과 boxes을 내림차순 배열로 정렬한 후, 시간을 효율적으로 사용하기 위해서 각 크레인이 어디까지 이동시켰는지의 인덱스를 관리하는 positions과 박스를 이동시킨지의 여부를 관리하는 moved 배열을 사용했습니다. 모든 박스가 이동할 때까지, 각 크래인을 순서대로, 아직 옮기지 않은 박스(크래인의 무게 제한 아래인) 를 순서대로 이동하면서, 두가지 배열을 조작하도록 했습니다. 한번의 크래인 순회가 끝나면, 전체 count를 증가시키고, 모든 박스가 옮겨졌을 때, 최종 count을 출력하도록 했습니다. 

##### 알고리즘 인터뷰 답변 보완
크레인과 박스를 내림차순으로 정렬한 후, 시간을 효율적으로 관리하기 위해 두 개의 배열을 사용했습니다. <mark>하나는 각 크레인이 현재 어디까지 작업했는지를 나타내는 positions 배열이고</mark>, 다른 하나는 각 박스의 이동 여부를 나타내는 moved 배열입니다. 모든 박스가 옮겨질 때까지, 각 크레인을 순서대로 순회하며 아직 옮기지 않았고 해당 크레인의 무게 제한 이하인 박스를 찾습니다. 조건을 만족하는 박스를 찾으면 이동시키고, <mark>해당 정보를 두 배열에 반영합니다.</mark> 모든 크레인이 한 번씩 순회할 때마다 전체 작업 시간을 의미하는 count를 증가시키고, 결국 모든 박스가 이동되었을 때 최종 count 값을 출력합니다.

### 🔹 코드

```python
import sys
from collections import deque

input = sys.stdin.readline

N = int(input())
restrictions = list(map(int, input().split()))
M = int(input())
boxes = list(map(int, input().split()))
if max(restrictions) < max(boxes) :
    print(-1)
    exit()
restrictions.sort(reverse=True)
boxes.sort(reverse=True)
count = 0


positions = [0]*N  # 각 크레인이 boxes 어디까지 옮겼는지 인덱스
moved = [False]*M  # 옮겼는지 여부
count = 0
moved_count = 0

while moved_count < M:
    for i in range(N):  # 각 크레인 순서대로
        while positions[i] < M:
            # 아직 안 옮겼고 크레인 무게 제한 이하이면
            if not moved[positions[i]] and boxes[positions[i]] <= restrictions[i]:
                moved[positions[i]] = True
                moved_count += 1
                positions[i] += 1
                break
            positions[i] += 1
    count += 1

print(count)
```

### 🔹 시간 복잡도

- `O(MN )`
- 분석/이유 : 최대 M.N만큼 순회
