### PR TITLE
[백준 1715번] : 카드 정렬하기

### DIFF
--- a/py/1715.py
+++ b/py/1715.py
@@ -1,0 +1,19 @@
+import heapq
+
+N = int(input())
+cards = []
+for _ in range(N) :
+    cards.append(int(input()))
+    
+heapq.heapify(cards)
+answer = 0
+
+# 카드가 하나로 합쳐질 때까지
+while len(cards) > 1 :
+    card1 = heapq.heappop(cards)
+    card2 = heapq.heappop(cards)
+    
+    answer += (card1 + card2)
+    heapq.heappush(cards, (card1+card2))
+
+print(answer)


### PR DESCRIPTION
## 📄 문제 정보

- **플랫폼**: 백준
- **문제 번호 / 이름**: 1715/카드 정렬하기
- **링크**: https://www.acmicpc.net/problem/1715

---

## ❓ 문제 설명

> 정렬된 두 묶음의 숫자 카드가 있다고 하자. 각 묶음의 카드의 수를 A, B라 하면 보통 두 묶음을 합쳐서 하나로 만드는 데에는 A+B 번의 비교를 해야 한다. 이를테면, 20장의 숫자 카드 묶음과 30장의 숫자 카드 묶음을 합치려면 50번의 비교가 필요하다.
매우 많은 숫자 카드 묶음이 책상 위에 놓여 있다. 이들을 두 묶음씩 골라 서로 합쳐나간다면, 고르는 순서에 따라서 비교 횟수가 매우 달라진다. 예를 들어 10장, 20장, 40장의 묶음이 있다면 10장과 20장을 합친 뒤, 합친 30장 묶음과 40장을 합친다면 (10 + 20) + (30 + 40) = 100번의 비교가 필요하다. 그러나 10장과 40장을 합친 뒤, 합친 50장 묶음과 20장을 합친다면 (10 + 40) + (50 + 20) = 120 번의 비교가 필요하므로 덜 효율적인 방법이다.
N개의 숫자 카드 묶음의 각각의 크기가 주어질 때, 최소한 몇 번의 비교가 필요한지를 구하는 프로그램을 작성하시오.



---

## ✏️ 문제 조건

- **입력**: 첫째 줄에 N이 주어진다. (1 ≤ N ≤ 100,000) 이어서 N개의 줄에 걸쳐 숫자 카드 묶음의 각각의 크기가 주어진다. 숫자 카드 묶음의 크기는 1,000보다 작거나 같은 양의 정수이다.
- **출력**: 첫째 줄에 최소 비교 횟수를 출력한다.
- **제약조건**:
- **시간/공간 제한**: 2초, 128MB
- 시간 제한 해석 : N이 최대 100,000일 때 1초는 O(n루트n), O(n**2)은 안됨
- 공간 제한 해석 : 

---

## 💡 아이디어 / 접근
자유롭게 적기. 정말 생각 그대로.

- 처음 떠올린 풀이 아이디어
    - 처음에는 그냥 sort(), 정렬을 한 후, 하나씩 앞에서부터 더하면 될 줄 알았습니다. 즉, (1,2,3,4,5)가 있으면 1,2를 합쳐서 (3,3,4,5). 33을 합쳐서(6,4,5), ..( 15) 
    - 근데 이렇게 하면 틀리더라구요. 왜인지 잘 모르겠어서, 깊게 생각해보면, (1,1,1,1,1,1,1,1,1,2,2,2,2.. )이런 식으로 카드가 있는 상태에서 앞에서부터 하면...! (2,1111111112222), (3,111111112222),(4,11111111112222), ... ( 10 222) -> 이런 식으로 비효율적으로 처리가 된다. (2,11111222)->(2,2,1111,222)->(2,2,2,11,222) 이런 식으로 제일 적은 양의 카드부터 합치도록 해야한다. 

- 고려했던 다른 접근
    - heapq를 사용해서 제일 작은 수의 카드를 매번 꺼내서, 합치고, 다시 heapq에 넣는 방식으로 접근해야 한다. 

- 선택한 접근 이유
    - heapq

---

## ✅ 내 풀이

### 🔹 풀이 설명

##### 알고리즘 인터뷰 답변
heapq를 사용해서, 카드를 관리했습니다. 제일 작은 카드 양을 매번 2개씩 꺼내서, 합친 후에 다시 heapq에 넣었습니다. 이때 카드양 만큼 비교 연산을 했기에 answer에 합쳤습니다. heapq 배열의 길이가 1이  될 때까지 반복했습니다 

##### 알고리즘 인터뷰 답변 보완
heapq를 사용해 항상 가장 작은 두 카드 묶음을 먼저 합쳤습니다. 이렇게 하면 전체 비교 횟수를 최소화할 수 있기 때문에 그리디 접근이 됩니다. 우선 모든 카드 묶음을 힙으로 만든 뒤(heapify), 힙에서 두 묶음을 꺼내(heappop) 합친 후 다시 힙에 넣는 과정을 반복했습니다. 힙의 크기가 1이 될 때까지 이 과정을 수행하면서 <mark>매번 합친 값을 answer에 더해 총 비교 횟수를 계산</mark>했습니다. heapq를 사용했기 때문에 두 묶음을 꺼내고 다시 넣는 과정이 O(log N)으로 처리돼 전체 시간 복잡도는 O(N log N)입니다.

### 🔹 코드

```python

import heapq

N = int(input())
cards = []
for _ in range(N) :
    cards.append(int(input()))
    
heapq.heapify(cards)
answer = 0

while len(cards) > 1 :
    card1 = heapq.heappop(cards)
    card2 = heapq.heappop(cards)
    
    answer += (card1 + card2)
    heapq.heappush(cards, (card1+card2))

print(answer)
```

### 🔹 시간 복잡도

- `O(N log N )`
- 분석/이유 : 힙 조작은 logN이고, 이를 N만큼 순회하면서 한다. 

---

## 🔍 다른 풀이 / 참고 풀이

> 다른 사람의 풀이 아이디어나 블로그, 해설 등에서 참고한 풀이
> 나와의 차이점, 배울 점, 내 풀이가 더 좋은 점 등.

---

### 풀이 #1

- 설명: 
    - 다 비슷한 방식으로 한다.
   

- 코드:

```python
import heapq

nums = []
result = 0
n = int(input())
for _ in range(n):
    heapq.heappush(nums, int(input()))
while len(nums) > 1:
    n1 = heapq.heappop(nums)
    n2 = heapq.heappop(nums)
    heapq.heappush(nums, n1 + n2)
    result += (n1 + n2)
print(result)

```

## 📝 배운 점 / 정리

-  오랜만에 heapq를 접했다. 가장 작은 수, 가장 큰 수를 다룰 때 heapq를 생각해 내야 하고, 이때 heapq는 log N의 시간 복잡도를 갖는 다는 것을 기억해야 한다. 
- 그리디에서 heapq가 많이 쓰인다. 

---

