### PR TITLE
[백준20366] : 같이 눈사람 만들래? 

### DIFF
--- a/py/20366.py
+++ b/py/20366.py
@@ -1,0 +1,34 @@
+import sys
+
+input = sys.stdin.readline
+from itertools import combinations
+
+N= int(input())
+balls = list(map(int, input().split()))
+
+pairs = set()
+
+for first_idx in range(N - 1) :
+    for second_idx in range(first_idx + 1 , N) :
+        # 합, i , j
+        pairs.add((balls[first_idx] + balls[second_idx], first_idx, second_idx))
+
+pairs = list(pairs)
+pairs.sort()
+print(pairs)
+answer = float('inf')
+
+
+# 인접 pair만 비교하면 됨
+for i in range(len(pairs) - 1):
+    s1, i1, j1 = pairs[i]
+    s2, i2, j2 = pairs[i+1]
+
+    # 4개의 index가 전부 달라야 함
+    if len({i1, j1, i2, j2}) == 4:
+        answer = min(answer, abs(s1 - s2))
+        if answer == 0:
+            print(0)
+            sys.exit()
+
+print(answer)


### PR DESCRIPTION
## 📄 문제 정보

- **플랫폼**: 백준
- **문제 번호 / 이름**: 20366/같이 눈사람 만들래?
- **링크**: https://www.acmicpc.net/problem/20366

---

## ❓ 문제 설명

> 언니 엘자와 동생 안나에게는 N개의 눈덩이가 있다. 각 눈덩이 i (1 ≤ i ≤ N)의 지름은 Hi 이다. 하나의 눈사람은 두 개의 눈덩이로 구성되며, 눈덩이 하나를 아래에 두고 그 눈덩이보다 크지 않은 다른 눈덩이를 쌓아올리는 방식으로 만들 수 있다. 이때, 눈사람의 키는 두 눈덩이 지름의 합과 같다.
엘자와 안나는 눈덩이 N개 중 서로 다른 4개를 골라서 눈사람을 각각 1개씩, 총 2개를 만들려고 한다. 두 자매는 두 눈사람의 키의 차이가 작을수록 두 눈사람의 사이가 좋을 것이라고 믿는다. 우리는 엘자와 안나가 가장 사이좋은 두 눈사람을 만들기 위해서 도와주려고 한다.
주어진 N개의 눈덩이를 이용하여 만들 수 있는 두 눈사람의 키 차이 중 최솟값을 구하는 프로그램을 작성하시오.

---

## ✏️ 문제 조건

- **입력**: 첫째 줄에 N (4 ≤ N ≤ 600)이 주어진다.
둘째 줄에는 각 눈덩이 i (1 ≤ i ≤ N)의 지름을 의미하는 정수 Hi (1 ≤ Hi ≤ 109)가 공백으로 구분되어 주어진다.
- **출력**: 만들 수 있는 두 눈사람의 키 차이 중 최솟값을 나타내는 정수를 출력하라.
- **제약조건**:
- **시간/공간 제한** : 2초, 1024MB
- 시간 제한 해석 : BruteForce, 그리고 BFS, DFS와 같은 완전 탐색은 n <= 10일 때만 (1초 ) 가능하다. 그렇기에 N=600일 때에는 O(n**2)까지 된다고 생각하면 된다. (500에서 n**3 컷됨) 

---

## 💡 아이디어 / 접근
자유롭게 적기. 정말 생각 그대로.

- 처음 떠올린 풀이 아이디어
    - BruteForce 아이디어를 구체화하기 위해서 itertools의 combinations을 사용해서, 있는 N 중 4개를 뽑아, 최소의 차이를 구하는 방식을 처음 사용했다. 이는 조합 생성이 O(N**4)이기에 n=500 이하여도 힘들다

- 고려했던 다른 접근
    - pair를 사용해서 가능한 모든 2개의 눈덩이 합과 idx을 저장했다. 그리고 pair들만 비교하고, idx가 겹치지 않을 때의 최소 차이를 구하도록 했다. 이 과정에서 모든 pair들끼리 비교를 하도록 해서, pair들끼리 중첩이 되어서 실질적으로 O(N**4)여서 시간 초과였다. 

- 선택한 접근 이유
    -  마지막으로는 pair를 정렬하여 모든 pair를 비교하는 것이 아닌 인접 pair만 확인하도록 했다. 두칸 이상 떨어진 원소의 차이가 절대로 최소가 될 수 없기에, 인접한 pair만 비교해도 된다. 

---

## ✅ 내 풀이

### 🔹 풀이 설명

##### 알고리즘 인터뷰 답변
가능한 눈덩이의 합, 눈덩이의 두 인덱스를 저장한 set을 관리했습니다. 이 set에는 가능한 모든 조합이 저장되어있습니다. 이 set을 올림차순으로 정렬을 한 후, 옆과 비교하면서 최소 차이를 찾도록 했습니다. (idx가 하나도 겹치지 않을 때만 고려하여, 차이를 갱신하도록 했습니다. 차이가 0인 경우, 더 이상 갱신 될 수 없기에, exit()을 하도록 했습니다. 

##### 알고리즘 인터뷰 답변 보완
가능한 모든 눈덩이 쌍을 만들고, 각 쌍의 합과 해당 눈덩이의 두 인덱스를 저장한 뒤<mark> set에 넣어 중복 없이 관리했습니다.</mark> 이후 이 쌍들을 합 기준으로 오름차순 정렬했고, 정렬된 리스트를 순회하면서 인접한 쌍부터 비교해 두 합의 차이를 계산했습니다. 이때 네 개의 인덱스가 전부 달라야만 유효한 비교로 간주해 최소 차이를 갱신했고, <mark>만약 차이가 0이 되는 순간 더 이상 더 좋은 답이 나올 수 없으므로 즉시 exit()으로 프로그램을 종료했습니다.</mark>

이 방식은 **쌍 생성(O(N²)) + 정렬(O(N² log N)) + 인접 비교(O(N²))**로, 처음의 조합 기반 완전탐색(O(N⁴))보다 훨씬 효율적으로 최소 차이를 찾을 수 있습니다.
### 🔹 코드

```python
import sys

input = sys.stdin.readline

N= int(input())
balls = list(map(int, input().split()))

pairs = set()

for first_idx in range(N - 1) :
    for second_idx in range(first_idx + 1 , N) :
        # 합, i , j
        pairs.add((balls[first_idx] + balls[second_idx], first_idx, second_idx))

pairs = list(pairs)
pairs.sort()
print(pairs)
answer = float('inf')


# 인접 pair만 비교하면 됨
for i in range(len(pairs) - 1):
    s1, i1, j1 = pairs[i]
    s2, i2, j2 = pairs[i+1]

    # 4개의 index가 전부 달라야 함
    if len({i1, j1, i2, j2}) == 4:
        answer = min(answer, abs(s1 - s2))
        if answer == 0:
            print(0)
            sys.exit()

print(answer)
```

### 🔹 시간 복잡도

- `O(N**2 )`
- 분석/이유 : 

---

## 🔍 다른 풀이 / 참고 풀이

> 다른 사람의 풀이 아이디어나 블로그, 해설 등에서 참고한 풀이
> 나와의 차이점, 배울 점, 내 풀이가 더 좋은 점 등.

---

### 풀이 #1

- 설명: 
    - 이 코드는 큰 눈사람 1쌍을 고정하고 나머지를 투 포인터로 찾는 전형적인 3중 루프 풀이
    - (a,b,c,d) 가 있을 때(올림차순 정렬) 결국에 최소 차이가 되는 것은 a,d - b,c 임을 사용했네...!
    - 그래서 제일 큰 양쪽 a,d를 (s, e)로 고정을 하고, 투포인터로 b,c를 바꿔가면서 값을 찾은 것. 

- 코드:

```python
n = int(input())
diameter = sorted(list(map(int, input().split())))
ans = int(1e9)
 
# 두 눈사람의 키차이 : (1,4)-(2,3)
# 큰 눈사람 고정
for s in range(n-3):
    for e in range(s+3, n):
        l, r = s+1, e-1
        while l <= r:
            diff = (diameter[s]+diameter[e])-(diameter[l]+diameter[r])
            if diff == 0:
                print(0)
                exit()
            elif diff > 0:
                l += 1
            else:
                r -= 1
            if abs(diff) < ans:
                ans = abs(diff)
            
print(ans)
```