### PR TITLE
[백준 11947] 통나무 건너뛰기

### DIFF
--- a/py/11947.py
+++ b/py/11947.py
@@ -1,0 +1,38 @@
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+
+T = int(input())
+
+for t in range(T) :
+    N = int(input())
+    logs = list(map(int, input().split()))
+    logs.sort()
+    answer = deque()
+    diff = 0
+    
+    
+    for log in logs :
+        print(answer, diff)
+        if len(answer) < 2 :
+            answer.append(log)
+        # log가 맨끝, 또는 맨 앞이랑 같을 경우에는, 같지 않은 쪽으로 붙이기. 
+        elif answer[0] == log or answer[-1] == log :
+            if answer[0] == log :
+                diff = max(diff, abs(log - answer[-1]))
+                answer.append(log)
+            else :
+                diff = max(diff, abs(log - answer[0]))
+                answer.appendleft(log)
+        # log는 순차적으로 증가하기 때문에, 더 answer의 양쪽 끝 중 더 작은 쪽에 붙이기
+        elif answer[0] <  answer[-1] :
+            diff = max(diff, abs(log-answer[0]))
+            answer.appendleft(log)
+        else :
+            diff = max(diff, abs(log - answer[-1]))
+            answer.append(log)
+    diff = max(diff, abs(answer[0]-answer[-1]))
+    print(diff)
+    


### PR DESCRIPTION
## 🚀 이슈 번호

**Resolve:** {#1533}

## 🧩 문제 해결

**스스로 해결:** ✅

### 🔎 접근 과정

> 문제 해결을 위한 접근 방식을 설명해주세요.

- 🔹 **어떤 알고리즘을 사용했는지** : 그리디? 
- 🔹 **어떤 방식으로 접근했는지**
- 정렬된 통나무들을 하나씩 정답에 붙이면서, 최대 차이를 구하는 것이라고 생각해서 그리디로 접근했습니다. 정렬된 통나무 리스트를 순회하며, answer에 붙였고, 다음 조건을 고려하며 answer에 추가했습니다.
    - answer의 [0]과 동일할 경우 오른쪽에 붙이기
    - answer의 [-1]과 동일할 경우 왼쪽에 붙이기
    - answer[-1] > answer[0] 일 경우, 더 작은 쪽인 왼쪽에 붙이기
    - answer[-1] <= answer[0]일 경우, 더 작은 쪽인 오른쪽에 붙이기

### ⏱️ 시간 복잡도

> **시간 복잡도 분석을 작성해주세요.** 

- **Big-O 표기법:** ` O(T * N )`
- **이유:** : 최악의 경우 수행 시간은 어느 정도인지 분석합니다. : 주어진 N개의 통나무들을 한번만 순회하기 때문입니다. 

## 💻 구현 코드

```python
import sys
from collections import deque

input = sys.stdin.readline


T = int(input())

for t in range(T) :
    N = int(input())
    logs = list(map(int, input().split()))
    logs.sort()
    answer = deque()
    diff = 0
    
    
    for log in logs :
        print(answer, diff)
        if len(answer) < 2 :
            answer.append(log)
        # log가 맨끝, 또는 맨 앞이랑 같을 경우에는, 같지 않은 쪽으로 붙이기. 
        elif answer[0] == log or answer[-1] == log :
            if answer[0] == log :
                diff = max(diff, abs(log - answer[-1]))
                answer.append(log)
            else :
                diff = max(diff, abs(log - answer[0]))
                answer.appendleft(log)
        # log는 순차적으로 증가하기 때문에, 더 answer의 양쪽 끝 중 더 작은 쪽에 붙이기
        elif answer[0] <  answer[-1] :
            diff = max(diff, abs(log-answer[0]))
            answer.appendleft(log)
        else :
            diff = max(diff, abs(log - answer[-1]))
            answer.append(log)
    diff = max(diff, abs(answer[0]-answer[-1]))
    print(diff)
    
```
