### PR TITLE
이대 8주 : 1330 번 k번째 수

### DIFF
--- a/py/1300.py
+++ b/py/1300.py
@@ -1,0 +1,22 @@
+import sys
+
+input = sys.stdin.readline
+N = int(input())
+k = int(input())
+
+lo, hi = 1, k
+ans = 0
+
+while lo <= hi:
+    mid = (lo + hi) // 2
+    cnt = 0
+    # mid 이하의 수가 몇 개인지 계산
+    for i in range(1, N + 1):
+        cnt += min(N, mid // i)
+    if cnt >= k:
+        ans = mid
+        hi = mid - 1
+    else:
+        lo = mid + 1
+
+print(ans)

--- a/py/1300_1.py
+++ b/py/1300_1.py
@@ -1,0 +1,11 @@
+N = int(input())
+k = int(input())
+
+def solve(kk) :
+    y = (kk - 1) // N
+    x = (kk - 1) - (N * y)
+    
+    return (y+1) * (x + 1)
+
+
+print(solve(k-1))


### PR DESCRIPTION
## 📄 문제 정보

- **플랫폼**: 백준
- **문제 번호 / 이름**: 1300 / jk번째 수
- **링크**: 

---

## ❓ 문제 설명

> 세준이는 크기가 N×N인 배열 A를 만들었다. 배열에 들어있는 수 A[i][j] = i×j 이다. 이 수를 일차원 배열 B에 넣으면 B의 크기는 N×N이 된다. B를 오름차순 정렬했을 때, B[k]를 구해보자.
배열 A와 B의 인덱스는 1부터 시작한다.

---

## ✏️ 문제 조건

- **입력**: 첫째 줄에 배열의 크기 N이 주어진다. N은 105보다 작거나 같은 자연수이다. 둘째 줄에 k가 주어진다. k는 min(109, N2)보다 작거나 같은 자연수이다.
- **출력**: B[k]를 출력한다.
- **제약조건**:
- **시간/공간 제한** : 1초, 128MB -> 이건 N**2의 배열을 사용할 수 없음

---

## 💡 아이디어 / 접근
- 선택한 접근 이유
    - matrix으로 표현된다면, k를 기반으로 대각선으로 쫙 선을 그어서 그 왼쪽만 생각하면 된다. 정렬된 리스트에서 k번째라는 것은 그보다 작은 수가 k라는 것입니다. `단조 증가 함수`라고 하는데, 단조 증가 함수에서는 k를 기준으로 이진 탐색을 할 수 있습니다. 단조 증가 함수에서 값이 증가하면 cnt도 같이 증가(또는 유지, 감소만 안됨)하는 구조이기 때문에 k번째 수 == cnt(x) >= k가 처음 성립하는 수. == 즉 어떠한 조건이 처음 만족 하는 수에는 이진 탐색이 제일 좋기에, 나머지는 이진 탐색 틀에 넣었습니다.

---

## ✅ 내 풀이

### 🔹 풀이 설명

##### 알고리즘 인터뷰 답변


##### 알고리즘 인터뷰 답변 보완


### 🔹 코드

```python
import sys

input = sys.stdin.readline
N = int(input())
k = int(input())

lo, hi = 1, k
ans = 0

while lo <= hi:
    mid = (lo + hi) // 2
    cnt = 0
    # mid 이하의 수가 몇 개인지 계산
    for i in range(1, N + 1):
        cnt += min(N, mid // i)
    if cnt >= k:
        ans = mid
        hi = mid - 1
    else:
        lo = mid + 1

print(ans)

```